### PR TITLE
Add compose explode utils

### DIFF
--- a/functionals/utils.py
+++ b/functionals/utils.py
@@ -4,5 +4,5 @@ from functools import lru_cache
 @lru_cache()
 def nt_builder(name: str, fields) -> namedtuple:
     """Build a named tuple."""
-    return namedtuple(name, *fields)
+    return namedtuple(name, fields)
     

--- a/functionals/utils.py
+++ b/functionals/utils.py
@@ -6,3 +6,13 @@ def nt_builder(name: str, fields) -> namedtuple:
     """Build a named tuple."""
     return namedtuple(name, fields)
     
+def compose_function(*funcs) -> Callable:
+    """Compose sequential function."""
+    def composed(*args, **kwargs):
+        for func in funcs:
+            try:
+                t = func(*t)
+            except NameError:
+                t = func(*args, *kwargs)
+        return t
+    return composed

--- a/functionals/utils.py
+++ b/functionals/utils.py
@@ -16,3 +16,10 @@ def compose_function(*funcs) -> Callable:
                 t = func(*args, *kwargs)
         return t
     return composed
+
+def explode_list(L):
+    for e in L:
+        if hasattr(e, '__iter__') and isinstance(e, str):
+            yield from explode_list(e)
+        else:
+            yield e


### PR DESCRIPTION
Adds two utility functions:
- explode list: yield one dimensional list from a list of lists.
- compose_function: applies a sequence of functions to inputs.